### PR TITLE
Add support to AWS SNS

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,6 +32,10 @@ Esse comando lê todas os tópicos SNS presentes na seção `topics` do arquivo 
 
 Esse comando lê todas as filas Amazon SQS presentes na seção `queues` do arquivo de configuração e envia o comando para criá-las no serviço configurado da AWS.
 
+### `infra subscribe-topics`
+
+Esse comando remove todas as inscrições dos tópicos e as cria conforme definido no parâmetro `subscribers` dentro dos itens da seção `topics` do arquivo de configuração.
+
 ### `msg send <queue_name> <message>`
 
 Esse comando recebe o nome de uma fila Amazon SQS e uma mensagem, e executa o envio dessa mensagem para a fila no serviço configurado da AWS.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,10 @@ Esse comando cria um exemplo do arquivo de configuração (`qldebugger.toml`) no
 
 Esse comando recebe o nome do um `event_source_mapping` configurado na seção de mesmo nome do arquivo de configuração, recebe mensagens da fila Amazon SQS configurada no parâmetro `queue` e executa o AWS Lambda nomeado no parâmetro `function_name`, exibindo sua saída no terminal.
 
+### `infra create-topics`
+
+Esse comando lê todas os tópicos SNS presentes na seção `topics` do arquivo de configuração e envia o comando para criá-los no serviço configurado da AWS.
+
 ### `infra create-queues`
 
 Esse comando lê todas as filas Amazon SQS presentes na seção `queues` do arquivo de configuração e envia o comando para criá-las no serviço configurado da AWS.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,6 +36,10 @@ Esse comando lê todas as filas Amazon SQS presentes na seção `queues` do arqu
 
 Esse comando remove todas as inscrições dos tópicos e as cria conforme definido no parâmetro `subscribers` dentro dos itens da seção `topics` do arquivo de configuração.
 
+### `msg publish <topic_name> <message> [<attributes>]`
+
+Esse comando recebe o nome de um tópico SNS, uma mensagem e opcionalmente seus atributos, e executa o envio dessa mensagem para o tópico no serviço configurado da AWS. Exemplo de atributos: `{"status":{"DataType":"String","StringValue":"success"}}`.
+
 ### `msg send <queue_name> <message>`
 
 Esse comando recebe o nome de uma fila Amazon SQS e uma mensagem, e executa o envio dessa mensagem para a fila no serviço configurado da AWS.

--- a/docs/config.md
+++ b/docs/config.md
@@ -56,6 +56,51 @@ Nome da região da AWS que deve ser utilizada.
 
 URL do endpoint para acessar a AWS. Normalmente utilizado por mocks.
 
+## `topics`
+
+Essa seção é opcional e descreve os tópicos SNS utilizados pelo Queue Lambda Debugger. Ela deve ser um dicionário, onde a chave é o nome do tópico, e o valor é um dicionário com seus parâmetros conforme descrito a seguir. Exemplos:
+
+```toml
+[topics]
+mytopic = {}
+
+[[topics.mytopic2.subscribers]]
+queue = "myqueue"
+raw_message_delivery = true
+filter_policy = "{\"status\":[\"success\"]}"
+```
+
+### `topics.*.subscribers`
+
+- Parâmetro opcional
+- Tipo: `List[ConfigTopicSubscriber]`
+- Valor padrão: `[]`
+
+Lista de inscrições para o tópico SNS.
+
+### `topics.*.subscribers[].queue`
+
+- Parâmetro obrigatório
+- Tipo: `str`
+
+Nome da fila SQS que deverá se inscrever para receber as mensagens publicadas nesse tópico.
+
+### `topics.*.subscribers[].raw_message_delivery`
+
+- Parâmatro opcional
+- Tipo: `bool`
+- Valor padrão: `False`
+
+Define se devem ser adicionado campos com informações do tópico nas mensagens entregues na fila SQS.
+
+### `topics.*.subscribers[].filter_policy`
+
+- Pametro opcional
+- Tipo: `Optional[str]`
+- Valor padrão: `None`
+
+Define um filtro para que apenas as mensagens que atendam os critérios sejam encaminhadas para a fila SQS. O exemplo `{\"status\":[\"success\"]}` encaminhará apenas mensagens com o atributo `status` igual a `success`.
+
 ## `queues`
 
 Essa seção é obrigatória e descreve as filas Amazon SQS utilizadas pelo Queue Lambda Debugger. Ela deve ser um dicionário, onde a chave é o nome da fila, e o valor é um dicionário com seus parâmetros, porém na versão atual nenhum parâmetro é definido. Exemplo:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ tomli = "^2.0"
 
 [tool.poetry.group.type.dependencies]
 aws-lambda-typing = "^2.13"
-boto3-stubs = {version = "^1.24", extras = ["sqs", "sts"]}
+boto3-stubs = {version = "^1.24", extras = ["sns", "sqs", "sts"]}
 
 [tool.poetry.group.dev.dependencies]
 pycodestyle = "^2.9"

--- a/qldebugger/actions/infra.py
+++ b/qldebugger/actions/infra.py
@@ -6,6 +6,15 @@ from qldebugger.config import get_config
 logger = logging.getLogger(__name__)
 
 
+def create_topics() -> None:
+    sns = get_client('sns')
+    topics = get_config().topics
+
+    for topic_name in topics:
+        logger.info('Creating %r topic...', topic_name)
+        sns.create_topic(Name=topic_name)
+
+
 def create_queues() -> None:
     sqs = get_client('sqs')
     queues = get_config().queues

--- a/qldebugger/actions/infra.py
+++ b/qldebugger/actions/infra.py
@@ -1,6 +1,6 @@
 import logging
 
-from qldebugger.aws import get_client
+from qldebugger.aws import get_account_id, get_client
 from qldebugger.config import get_config
 
 logger = logging.getLogger(__name__)
@@ -22,3 +22,30 @@ def create_queues() -> None:
     for queue_name in queues:
         logger.info('Creating %r queue...', queue_name)
         sqs.create_queue(QueueName=queue_name)
+
+
+def subscribe_topics() -> None:
+    sns = get_client('sns')
+    topics = get_config().topics
+    account_id = get_account_id()
+    region = sns.meta.region_name
+
+    subscriptions = sns.list_subscriptions()['Subscriptions']
+    for subscription in subscriptions:
+        logger.info('Unsubscribing %r queue (%r)...', subscription['Endpoint'], subscription['SubscriptionArn'])
+        sns.unsubscribe(SubscriptionArn=subscription['SubscriptionArn'])
+
+    for topic_name, config_topic in topics.items():
+        for subscriber in config_topic.subscribers:
+            logger.info('Subscribing %r topic to %r queue...', topic_name, subscriber.queue)
+            attributes = {
+                'RawMessageDelivery': 'true' if subscriber.raw_message_delivery else 'false',
+            }
+            if subscriber.filter_policy is not None:
+                attributes['FilterPolicy'] = subscriber.filter_policy
+            sns.subscribe(
+                TopicArn=f'arn:aws:sns:{region}:{account_id}:{topic_name}',
+                Protocol='sqs',
+                Endpoint=f'arn:aws:sqs:{region}:{account_id}:{subscriber.queue}',
+                Attributes=attributes,
+            )

--- a/qldebugger/actions/message.py
+++ b/qldebugger/actions/message.py
@@ -1,13 +1,30 @@
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Mapping
 
-from qldebugger.aws import get_client
+from qldebugger.aws import get_account_id, get_client
 
 if TYPE_CHECKING:
+    from mypy_boto3_sns.type_defs import MessageAttributeValueTypeDef
     from mypy_boto3_sqs.type_defs import ReceiveMessageResultTypeDef
 
 
 logger = logging.getLogger(__name__)
+
+
+def publish_message(
+    *,
+    topic_name: str,
+    message: str,
+    attributes: Mapping[str, 'MessageAttributeValueTypeDef'] = {},
+) -> None:
+    sns = get_client('sns')
+    arn = f'arn:aws:sns:{sns.meta.region_name}:{get_account_id()}:{topic_name}'
+    logger.info('Sending message to %r topic...', topic_name)
+    sns.publish(
+        TopicArn=arn,
+        Message=message,
+        MessageAttributes=attributes,
+    )
 
 
 def send_message(*, queue_name: str, message: str) -> None:

--- a/qldebugger/aws.py
+++ b/qldebugger/aws.py
@@ -8,10 +8,15 @@ from botocore.config import Config
 from .config import get_config
 
 if TYPE_CHECKING:
+    from mypy_boto3_sns import SNSClient
     from mypy_boto3_sqs import SQSClient
     from mypy_boto3_sts import STSClient
 
 logger = logging.getLogger(__name__)
+
+
+@overload
+def get_client(service_name: Literal['sns'], /) -> 'SNSClient': ...
 
 
 @overload

--- a/qldebugger/cli.py
+++ b/qldebugger/cli.py
@@ -60,6 +60,12 @@ def infra() -> None:
     ...
 
 
+@infra.command('create-topics')
+def infra_create_topics() -> None:
+    load_config(CONFIG_FILENAME)
+    actions.infra.create_topics()
+
+
 @infra.command('create-queues')
 def infra_create_queues() -> None:
     load_config(CONFIG_FILENAME)

--- a/qldebugger/cli.py
+++ b/qldebugger/cli.py
@@ -1,10 +1,15 @@
+import json
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING, Mapping
 
 import click
 
 from . import actions
 from .config import load_config
+
+if TYPE_CHECKING:
+    from mypy_boto3_sns.type_defs import MessageAttributeValueTypeDef
 
 CONFIG_FILENAME = Path('qldebugger.toml')
 
@@ -83,6 +88,15 @@ def infra_subscribe_topics() -> None:
 @cli.group()
 def msg() -> None:
     ...
+
+
+@msg.command('publish')
+@click.argument('topic_name')
+@click.argument('message')
+@click.argument('attributes', default='{}', type=json.loads)
+def msg_publish(topic_name: str, message: str, attributes: Mapping[str, 'MessageAttributeValueTypeDef']) -> None:
+    load_config(CONFIG_FILENAME)
+    actions.message.publish_message(topic_name=topic_name, message=message, attributes=attributes)
 
 
 @msg.command('send')

--- a/qldebugger/cli.py
+++ b/qldebugger/cli.py
@@ -72,6 +72,12 @@ def infra_create_queues() -> None:
     actions.infra.create_queues()
 
 
+@infra.command('subscribe-topics')
+def infra_subscribe_topics() -> None:
+    load_config(CONFIG_FILENAME)
+    actions.infra.subscribe_topics()
+
+
 # Msg
 
 @cli.group()

--- a/qldebugger/config/file_parser.py
+++ b/qldebugger/config/file_parser.py
@@ -1,4 +1,4 @@
-from typing import Any, BinaryIO, Dict, NamedTuple, Optional, Tuple
+from typing import Any, BinaryIO, Dict, List, NamedTuple, Optional, Tuple
 
 import tomli
 from pydantic import BaseModel, Field, validator
@@ -11,6 +11,16 @@ class ConfigAWS(BaseModel):
     session_token: Optional[str]
     region: Optional[str]
     endpoint_url: Optional[str]
+
+
+class ConfigTopicSubscriber(BaseModel):
+    queue: str
+    raw_message_delivery: bool = False
+    filter_policy: Optional[str] = None
+
+
+class ConfigTopic(BaseModel):
+    subscribers: List[ConfigTopicSubscriber] = Field(default_factory=list)
 
 
 class ConfigQueue(BaseModel):
@@ -45,6 +55,7 @@ class ConfigEventSourceMapping(BaseModel):
 
 class Config(BaseModel):
     aws: ConfigAWS = Field(default_factory=ConfigAWS)
+    topics: Dict[str, ConfigTopic] = Field(default_factory=dict)
     queues: Dict[str, ConfigQueue]
     lambdas: Dict[str, ConfigLambda]
     event_source_mapping: Dict[str, ConfigEventSourceMapping]

--- a/tests/qldebugger/actions/test_infra.py
+++ b/tests/qldebugger/actions/test_infra.py
@@ -1,8 +1,8 @@
 from random import randint
 from unittest.mock import Mock, patch
 
-from qldebugger.actions.infra import create_queues, create_topics
-from qldebugger.config.file_parser import ConfigQueue, ConfigTopic
+from qldebugger.actions.infra import create_queues, create_topics, subscribe_topics
+from qldebugger.config.file_parser import ConfigQueue, ConfigTopic, ConfigTopicSubscriber
 from tests.utils import randstr
 
 
@@ -36,3 +36,177 @@ class TestCreateQueues:
         assert mock_get_client.return_value.create_queue.call_count == len(queues_names)
         for queue_name in queues_names:
             mock_get_client.return_value.create_queue.assert_any_call(QueueName=queue_name)
+
+
+class TestSubscribeTopics:
+    @patch('qldebugger.actions.infra.get_client')
+    @patch('qldebugger.actions.infra.get_config')
+    @patch('qldebugger.actions.infra.get_account_id')
+    def test_topics_without_subscribers(
+        self,
+        mock_get_account_id: Mock,
+        mock_get_config: Mock,
+        mock_get_client: Mock,
+    ) -> None:
+        topics_names = [randstr() for _ in range(randint(2, 5))]
+
+        mock_get_config.return_value.topics = {topic_name: ConfigTopic() for topic_name in topics_names}
+
+        subscribe_topics()
+
+        mock_get_client.assert_called_once_with('sns')
+        mock_get_client.return_value.subscribe.assert_not_called()
+
+    @patch('qldebugger.actions.infra.get_client')
+    @patch('qldebugger.actions.infra.get_config')
+    @patch('qldebugger.actions.infra.get_account_id')
+    def test_topics_with_one_subscriber(
+        self,
+        mock_get_account_id: Mock,
+        mock_get_config: Mock,
+        mock_get_client: Mock,
+    ) -> None:
+        account_id = f'{randint(0, 999999999999):012}'
+        region = randstr()
+        topics_queues_names = [(randstr(), randstr()) for _ in range(randint(2, 5))]
+
+        mock_get_account_id.return_value = account_id
+        mock_get_config.return_value.topics = {
+            topic_name: ConfigTopic(subscribers=[ConfigTopicSubscriber(queue=queue_name)])
+            for topic_name, queue_name in topics_queues_names
+        }
+        mock_get_client.return_value.meta.region_name = region
+
+        subscribe_topics()
+
+        mock_get_client.assert_called_once_with('sns')
+        assert mock_get_client.return_value.subscribe.call_count == len(topics_queues_names)
+        for topic_name, queue_name in topics_queues_names:
+            mock_get_client.return_value.subscribe.assert_any_call(
+                TopicArn=f'arn:aws:sns:{region}:{account_id}:{topic_name}',
+                Protocol='sqs',
+                Endpoint=f'arn:aws:sqs:{region}:{account_id}:{queue_name}',
+                Attributes={'RawMessageDelivery': 'false'},
+            )
+
+    @patch('qldebugger.actions.infra.get_client')
+    @patch('qldebugger.actions.infra.get_config')
+    @patch('qldebugger.actions.infra.get_account_id')
+    def test_topic_with_multiple_subscribers(
+        self,
+        mock_get_account_id: Mock,
+        mock_get_config: Mock,
+        mock_get_client: Mock,
+    ) -> None:
+        account_id = f'{randint(0, 999999999999):012}'
+        region = randstr()
+        topic_name = randstr()
+        queues_names = [randstr() for _ in range(randint(2, 5))]
+
+        mock_get_account_id.return_value = account_id
+        mock_get_config.return_value.topics = {
+            topic_name: ConfigTopic(
+                subscribers=[ConfigTopicSubscriber(queue=queue_name) for queue_name in queues_names],
+            ),
+        }
+        mock_get_client.return_value.meta.region_name = region
+
+        subscribe_topics()
+
+        mock_get_client.assert_called_once_with('sns')
+        assert mock_get_client.return_value.subscribe.call_count == len(queues_names)
+        for queue_name in queues_names:
+            mock_get_client.return_value.subscribe.assert_any_call(
+                TopicArn=f'arn:aws:sns:{region}:{account_id}:{topic_name}',
+                Protocol='sqs',
+                Endpoint=f'arn:aws:sqs:{region}:{account_id}:{queue_name}',
+                Attributes={'RawMessageDelivery': 'false'},
+            )
+
+    @patch('qldebugger.actions.infra.get_client')
+    @patch('qldebugger.actions.infra.get_config')
+    @patch('qldebugger.actions.infra.get_account_id')
+    def test_raw_subscriber(
+        self,
+        mock_get_account_id: Mock,
+        mock_get_config: Mock,
+        mock_get_client: Mock,
+    ) -> None:
+        account_id = f'{randint(0, 999999999999):012}'
+        region = randstr()
+        topic_name = randstr()
+        queue_name = randstr()
+
+        mock_get_account_id.return_value = account_id
+        mock_get_config.return_value.topics = {
+            topic_name: ConfigTopic(
+                subscribers=[ConfigTopicSubscriber(queue=queue_name, raw_message_delivery=True)],
+            ),
+        }
+        mock_get_client.return_value.meta.region_name = region
+
+        subscribe_topics()
+
+        mock_get_client.assert_called_once_with('sns')
+        mock_get_client.return_value.subscribe.assert_called_once_with(
+            TopicArn=f'arn:aws:sns:{region}:{account_id}:{topic_name}',
+            Protocol='sqs',
+            Endpoint=f'arn:aws:sqs:{region}:{account_id}:{queue_name}',
+            Attributes={'RawMessageDelivery': 'true'},
+        )
+
+    @patch('qldebugger.actions.infra.get_client')
+    @patch('qldebugger.actions.infra.get_config')
+    @patch('qldebugger.actions.infra.get_account_id')
+    def test_subscriber_with_filter_policy(
+        self,
+        mock_get_account_id: Mock,
+        mock_get_config: Mock,
+        mock_get_client: Mock,
+    ) -> None:
+        account_id = f'{randint(0, 999999999999):012}'
+        region = randstr()
+        topic_name = randstr()
+        queue_name = randstr()
+        filter_policy = randstr()
+
+        mock_get_account_id.return_value = account_id
+        mock_get_config.return_value.topics = {
+            topic_name: ConfigTopic(
+                subscribers=[ConfigTopicSubscriber(queue=queue_name, filter_policy=filter_policy)],
+            ),
+        }
+        mock_get_client.return_value.meta.region_name = region
+
+        subscribe_topics()
+
+        mock_get_client.assert_called_once_with('sns')
+        mock_get_client.return_value.subscribe.assert_called_once_with(
+            TopicArn=f'arn:aws:sns:{region}:{account_id}:{topic_name}',
+            Protocol='sqs',
+            Endpoint=f'arn:aws:sqs:{region}:{account_id}:{queue_name}',
+            Attributes={'RawMessageDelivery': 'false', 'FilterPolicy': filter_policy},
+        )
+
+    @patch('qldebugger.actions.infra.get_client')
+    @patch('qldebugger.actions.infra.get_config')
+    @patch('qldebugger.actions.infra.get_account_id')
+    def test_remove_old_subscribers(
+        self,
+        mock_get_account_id: Mock,
+        mock_get_config: Mock,
+        mock_get_client: Mock,
+    ) -> None:
+        subscriptions = [randstr() for _ in range(randint(2, 5))]
+
+        mock_get_client.return_value.list_subscriptions.return_value = {'Subscriptions': [
+            {'SubscriptionArn': subscription, 'Endpoint': randstr()}
+            for subscription in subscriptions
+        ]}
+
+        subscribe_topics()
+
+        mock_get_client.assert_called_once_with('sns')
+        assert mock_get_client.return_value.unsubscribe.call_count == len(subscriptions)
+        for subscription in subscriptions:
+            mock_get_client.return_value.unsubscribe.assert_any_call(SubscriptionArn=subscription)

--- a/tests/qldebugger/actions/test_infra.py
+++ b/tests/qldebugger/actions/test_infra.py
@@ -1,9 +1,25 @@
 from random import randint
 from unittest.mock import Mock, patch
 
-from qldebugger.actions.infra import create_queues
-from qldebugger.config.file_parser import ConfigQueue
+from qldebugger.actions.infra import create_queues, create_topics
+from qldebugger.config.file_parser import ConfigQueue, ConfigTopic
 from tests.utils import randstr
+
+
+class TestCreateTopics:
+    @patch('qldebugger.actions.infra.get_client')
+    @patch('qldebugger.actions.infra.get_config')
+    def test_run(self, mock_get_config: Mock, mock_get_client: Mock) -> None:
+        topics_names = [randstr() for _ in range(randint(2, 5))]
+
+        mock_get_config.return_value.topics = {topic_name: ConfigTopic() for topic_name in topics_names}
+
+        create_topics()
+
+        mock_get_client.assert_called_once_with('sns')
+        assert mock_get_client.return_value.create_topic.call_count == len(topics_names)
+        for topic_name in topics_names:
+            mock_get_client.return_value.create_topic.assert_any_call(Name=topic_name)
 
 
 class TestCreateQueues:

--- a/tests/qldebugger/test_aws.py
+++ b/tests/qldebugger/test_aws.py
@@ -9,7 +9,7 @@ from tests.utils import randstr
 
 
 class TestGetClient:
-    @pytest.mark.parametrize('service', ['sqs', 'sts'])
+    @pytest.mark.parametrize('service', ['sns', 'sqs', 'sts'])
     @patch('qldebugger.aws.get_config')
     @patch('qldebugger.aws.boto3')
     def test_run(self, mock_boto3: Mock, mock_get_config: Mock, service: str) -> None:


### PR DESCRIPTION
- Add option to create SNS topics and subscribers in `qldebugger.toml`
- Add command `infra create-topics` to create topic in `qldebugger.toml` on AWS
- Add command `infra subscribe-topics` to subscribe SNS to SQS
- Add command `msg publish` to publish message in SNS topic