### PR TITLE
Add support to AWS SecretsManager

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,10 @@ Esse comando cria um exemplo do arquivo de configuração (`qldebugger.toml`) no
 
 Esse comando recebe o nome do um `event_source_mapping` configurado na seção de mesmo nome do arquivo de configuração, recebe mensagens da fila Amazon SQS configurada no parâmetro `queue` e executa o AWS Lambda nomeado no parâmetro `function_name`, exibindo sua saída no terminal.
 
+### `infra create-secrets`
+
+Esse comando lê todas os segredos do SecretsManager presentes na seção `secrets` do arquivo de configuração e envia o comando para criá-los ou atualizá-los no serviço configurado da AWS.
+
 ### `infra create-topics`
 
 Esse comando lê todas os tópicos SNS presentes na seção `topics` do arquivo de configuração e envia o comando para criá-los no serviço configurado da AWS.

--- a/docs/config.md
+++ b/docs/config.md
@@ -56,6 +56,30 @@ Nome da região da AWS que deve ser utilizada.
 
 URL do endpoint para acessar a AWS. Normalmente utilizado por mocks.
 
+## `secrets`
+
+Essa seção é opcional e descreve os segredos do SecretsManager utilizados pelo Queue Lambda Debugger. Ela deve ser um dicionário, onde a chave é o nome do segredo, e o valor é um dicionário indicando o tipo de segredo (string ou binário) e seu valor. Exemplos:
+
+```toml
+[secrets]
+stringSecret = {string = "abc"}
+binarySecret = {binary = "123"}
+```
+
+### `secrets.*.string`
+
+- Parâmetro obrigatório (conflita com `binary`)
+- Tipo: `str`
+
+Valor como string para o segredo.
+
+### `secrets.*.binary`
+
+- Parâmetro obrigatório (conflita com `string`)
+- Tipo: `str`
+
+Valor como binário para o segredo.
+
 ## `topics`
 
 Essa seção é opcional e descreve os tópicos SNS utilizados pelo Queue Lambda Debugger. Ela deve ser um dicionário, onde a chave é o nome do tópico, e o valor é um dicionário com seus parâmetros conforme descrito a seguir. Exemplos:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ tomli = "^2.0"
 
 [tool.poetry.group.type.dependencies]
 aws-lambda-typing = "^2.13"
-boto3-stubs = {version = "^1.24", extras = ["sns", "sqs", "sts"]}
+boto3-stubs = {version = "^1.24", extras = ["secretsmanager", "sns", "sqs", "sts"]}
 
 [tool.poetry.group.dev.dependencies]
 pycodestyle = "^2.9"

--- a/qldebugger/aws.py
+++ b/qldebugger/aws.py
@@ -8,11 +8,16 @@ from botocore.config import Config
 from .config import get_config
 
 if TYPE_CHECKING:
+    from mypy_boto3_secretsmanager import SecretsManagerClient
     from mypy_boto3_sns import SNSClient
     from mypy_boto3_sqs import SQSClient
     from mypy_boto3_sts import STSClient
 
 logger = logging.getLogger(__name__)
+
+
+@overload
+def get_client(service_name: Literal['secretsmanager'], /) -> 'SecretsManagerClient': ...
 
 
 @overload

--- a/qldebugger/cli.py
+++ b/qldebugger/cli.py
@@ -65,6 +65,12 @@ def infra() -> None:
     ...
 
 
+@infra.command('create-secrets')
+def infra_create_secrets() -> None:
+    load_config(CONFIG_FILENAME)
+    actions.infra.create_secrets()
+
+
 @infra.command('create-topics')
 def infra_create_topics() -> None:
     load_config(CONFIG_FILENAME)

--- a/tests/qldebugger/test_aws.py
+++ b/tests/qldebugger/test_aws.py
@@ -9,7 +9,7 @@ from tests.utils import randstr
 
 
 class TestGetClient:
-    @pytest.mark.parametrize('service', ['sns', 'sqs', 'sts'])
+    @pytest.mark.parametrize('service', ['secretsmanager', 'sns', 'sqs', 'sts'])
     @patch('qldebugger.aws.get_config')
     @patch('qldebugger.aws.boto3')
     def test_run(self, mock_boto3: Mock, mock_get_config: Mock, service: str) -> None:


### PR DESCRIPTION
- Add option to create secret in `qldebugger.toml`
- Add command `infra create-secrets` to create secrets in SecretsManager