### PR TITLE
Temporary coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 /.mypy_cache
 /.pytest_cache
 /.coverage
+/.coverage.*
 
 # Docs
 /docs-site

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ clean-build:
 clean-cache:
 	find $(srcdir) $(testsdir) -name '__pycache__' -exec rm -rf {} +
 	find $(srcdir) $(testsdir) -type d -empty -delete
-	rm -rf .ruff_cache .mypy_cache .pytest_cache .coverage
+	rm -rf .ruff_cache .mypy_cache .pytest_cache .coverage .coverage.*
 
 clean-docs:
 	rm -rf docs-site


### PR DESCRIPTION
- Ignore temporary coverage files
- Delete temporary coverage files when cleaning the project