### PR TITLE
Add redrive policy for queues

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -127,13 +127,35 @@ Define um filtro para que apenas as mensagens que atendam os critérios sejam en
 
 ## `queues`
 
-Essa seção é obrigatória e descreve as filas Amazon SQS utilizadas pelo Queue Lambda Debugger. Ela deve ser um dicionário, onde a chave é o nome da fila, e o valor é um dicionário com seus parâmetros, porém na versão atual nenhum parâmetro é definido. Exemplo:
+Essa seção é obrigatória e descreve as filas Amazon SQS utilizadas pelo Queue Lambda Debugger. Ela deve ser um dicionário, onde a chave é o nome da fila, e o valor é um dicionário com seus parâmetros. Exemplo:
 
 ```toml
 [queues]
-myqueue = {}
+myqueue = {redrive_policy = {dead_letter_queue = "myqueue2", max_receive_count = 3}}
 myqueue2 = {}
 ```
+
+### `queues.*.redrive_policy`
+
+- Parâmetro opcional
+- Tipo: `Optional[ConfigQueueRedrivePolicy]`
+- Valor padrão: `None`
+
+Define uma política para retentativas de processamento de mensagens da fila, enviando-a para outra fila ao ocorerrem certa quantidade de erros no processamento daquela mensagem.
+
+### `queues.*.redrive_policy.dead_letter_queue`
+
+- Parâmetro obrigatório
+- Tipo: `str`
+
+Nome da fila para onde a mensagem deverá ser enviada após certa quantidade de tentativas de processamento.
+
+### `queues.*.redrive_policy.max_receive_count`
+
+- Parâmetro obrigatório
+- Tipo: `int`
+
+Quantas vezes um mesma mensagem pode ser recuperada da fila antes de enviá-la para a fila dead letter.
 
 ## `lambdas`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 python = "^3.8"
 boto3 = "^1.35"
 click = "^8.1"
+graphlib_backport = {version = "^1.1", python = "<3.9"}
 pydantic = "^2.8"
 tomli = "^2.0"
 
@@ -80,6 +81,12 @@ sqlite_cache = true
 strict = true
 plugins = ["pydantic.mypy"]
 files = ["src/**/*.py", "tests/**/*.py"]
+
+[[tool.mypy.overrides]]
+module = [
+  "graphlib.*",
+]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/qldebugger/config/file_parser.py
+++ b/src/qldebugger/config/file_parser.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, BinaryIO, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import tomli
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, PositiveInt, field_validator
 
 
 class ConfigAWS(BaseModel):
@@ -44,7 +44,13 @@ class ConfigTopic(BaseModel):
     subscribers: List[ConfigTopicSubscriber] = Field(default_factory=list)
 
 
-class ConfigQueue(BaseModel): ...
+class ConfigQueueRedrivePolicy(BaseModel):
+    dead_letter_queue: str
+    max_receive_count: PositiveInt
+
+
+class ConfigQueue(BaseModel):
+    redrive_policy: Optional[ConfigQueueRedrivePolicy] = None
 
 
 class NameHandlerTuple(NamedTuple):

--- a/tests/qldebugger/config/test_file_parser.py
+++ b/tests/qldebugger/config/test_file_parser.py
@@ -12,6 +12,7 @@ from qldebugger.config.file_parser import (
     ConfigEventSourceMapping,
     ConfigLambda,
     ConfigQueue,
+    ConfigQueueRedrivePolicy,
     ConfigSecretBinary,
     ConfigSecretString,
     ConfigTopic,
@@ -71,11 +72,25 @@ class TestConfigTopic:
         }
 
 
+class TestConfigQueueRedrivePolicy:
+    def test_required_fields(self) -> None:
+        required_fields = ['dead_letter_queue', 'max_receive_count']
+
+        with pytest.raises(ValidationError) as exc_info:
+            ConfigQueueRedrivePolicy.model_validate({})
+
+        assert {error['loc'] for error in exc_info.value.errors() if error['type'] == 'missing'} == {
+            (field,) for field in required_fields
+        }
+
+
 class TestConfigQueue:
-    def test_empty_object(self) -> None:
+    def test_default_values(self) -> None:
         returned = ConfigQueue()
 
-        assert returned.model_dump() == {}
+        assert returned.model_dump() == {
+            'redrive_policy': None,
+        }
 
 
 class TestNameHandlerTuple:


### PR DESCRIPTION
- Add `redrive_policy` option in queue config
- Implements dead letter queue on `infra create_queues` command
- Document `redrive_policy` option